### PR TITLE
Add top level response model

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,4 @@ db.sqlite3*
 
 # IDEs
 .idea
+.vscode

--- a/fastapi_crudrouter/core/_base.py
+++ b/fastapi_crudrouter/core/_base.py
@@ -49,7 +49,7 @@ class CRUDGenerator(Generic[T], APIRouter):
         prefix = str(prefix if prefix else self.schema.__name__).lower()
         prefix = self._base_path + prefix.strip("/")
         tags = tags or [prefix.strip("/").capitalize()]
-        response_model = kwargs.pop("response_model", None)
+        self.response_model = kwargs.pop("response_model", None)
         super().__init__(prefix=prefix, tags=tags, **kwargs)
 
         if get_all_route:
@@ -57,7 +57,7 @@ class CRUDGenerator(Generic[T], APIRouter):
                 "",
                 self._get_all(),
                 methods=["GET"],
-                response_model=response_model or Optional[List[self.schema]],  # type: ignore
+                response_model=self.response_model or Optional[List[self.schema]],  # type: ignore
                 summary="Get All",
                 dependencies=get_all_route,
             )
@@ -67,7 +67,7 @@ class CRUDGenerator(Generic[T], APIRouter):
                 "",
                 self._create(),
                 methods=["POST"],
-                response_model=response_model or self.schema,
+                response_model=self.response_model or self.schema,
                 summary="Create One",
                 dependencies=create_route,
             )
@@ -77,7 +77,7 @@ class CRUDGenerator(Generic[T], APIRouter):
                 "",
                 self._delete_all(),
                 methods=["DELETE"],
-                response_model=response_model or Optional[List[self.schema]],  # type: ignore
+                response_model=self.response_model or Optional[List[self.schema]],  # type: ignore
                 summary="Delete All",
                 dependencies=delete_all_route,
             )
@@ -87,7 +87,7 @@ class CRUDGenerator(Generic[T], APIRouter):
                 "/{item_id}",
                 self._get_one(),
                 methods=["GET"],
-                response_model=response_model or self.schema,
+                response_model=self.response_model or self.schema,
                 summary="Get One",
                 dependencies=get_one_route,
             )
@@ -97,7 +97,7 @@ class CRUDGenerator(Generic[T], APIRouter):
                 "/{item_id}",
                 self._update(),
                 methods=["PUT"],
-                response_model=response_model or self.schema,
+                response_model=self.response_model or self.schema,
                 summary="Update One",
                 dependencies=update_route,
             )
@@ -107,7 +107,7 @@ class CRUDGenerator(Generic[T], APIRouter):
                 "/{item_id}",
                 self._delete_one(),
                 methods=["DELETE"],
-                response_model=response_model or self.schema,
+                response_model=self.response_model or self.schema,
                 summary="Delete One",
                 dependencies=delete_one_route,
             )

--- a/fastapi_crudrouter/core/_base.py
+++ b/fastapi_crudrouter/core/_base.py
@@ -49,7 +49,7 @@ class CRUDGenerator(Generic[T], APIRouter):
         prefix = str(prefix if prefix else self.schema.__name__).lower()
         prefix = self._base_path + prefix.strip("/")
         tags = tags or [prefix.strip("/").capitalize()]
-
+        response_model = kwargs.pop("response_model", None)
         super().__init__(prefix=prefix, tags=tags, **kwargs)
 
         if get_all_route:
@@ -57,7 +57,7 @@ class CRUDGenerator(Generic[T], APIRouter):
                 "",
                 self._get_all(),
                 methods=["GET"],
-                response_model=Optional[List[self.schema]],  # type: ignore
+                response_model=response_model or Optional[List[self.schema]],  # type: ignore
                 summary="Get All",
                 dependencies=get_all_route,
             )
@@ -67,7 +67,7 @@ class CRUDGenerator(Generic[T], APIRouter):
                 "",
                 self._create(),
                 methods=["POST"],
-                response_model=self.schema,
+                response_model=response_model or self.schema,
                 summary="Create One",
                 dependencies=create_route,
             )
@@ -77,7 +77,7 @@ class CRUDGenerator(Generic[T], APIRouter):
                 "",
                 self._delete_all(),
                 methods=["DELETE"],
-                response_model=Optional[List[self.schema]],  # type: ignore
+                response_model=response_model or Optional[List[self.schema]],  # type: ignore
                 summary="Delete All",
                 dependencies=delete_all_route,
             )
@@ -87,7 +87,7 @@ class CRUDGenerator(Generic[T], APIRouter):
                 "/{item_id}",
                 self._get_one(),
                 methods=["GET"],
-                response_model=self.schema,
+                response_model=response_model or self.schema,
                 summary="Get One",
                 dependencies=get_one_route,
             )
@@ -97,7 +97,7 @@ class CRUDGenerator(Generic[T], APIRouter):
                 "/{item_id}",
                 self._update(),
                 methods=["PUT"],
-                response_model=self.schema,
+                response_model=response_model or self.schema,
                 summary="Update One",
                 dependencies=update_route,
             )
@@ -107,7 +107,7 @@ class CRUDGenerator(Generic[T], APIRouter):
                 "/{item_id}",
                 self._delete_one(),
                 methods=["DELETE"],
-                response_model=self.schema,
+                response_model=response_model or self.schema,
                 summary="Delete One",
                 dependencies=delete_one_route,
             )


### PR DESCRIPTION
Currently, the `response_model` for all endpoints is using the schema passed to the key `schema`, which may be the most common behaviour need. However it doesn't allow change it in order to provide a custom `response_model`,

This PR makes it possible to set a top level `response_model` to be used to all endpoint.

A simple example:
```python
class GardenSchema(BaseModel):
    status: str
    results: list[OnionSchema]
    owner: str

router = TortoiseCRUDRouter(
    db_model=Onion,  # tortoise model for example
    schema=OnionSchema, # pydantic schema generated by tortoise
    # other configs
    response_model=GardenSchema # This schema will be passed to all endpoints to the response_model field
)
```
Currently, the `response_model` will is present inside `kwargs`, so it's optional and the change to the core code was minimal. Also, there isn't any unit test for it, but any current test is broken by this new change. 

TODO:
-  Find the best way to test this new feature using the current library tests setup.


